### PR TITLE
Update xrefs to docs for new URLs

### DIFF
--- a/01-anneal-schedule.ipynb
+++ b/01-anneal-schedule.ipynb
@@ -68,7 +68,7 @@
    "source": [
     "## Understanding the Anneal Schedule\n",
     "\n",
-    "The [Getting Started with the D-Wave System](https://docs.dwavesys.com/docs/latest/doc_getting_started.html) document describes quantum annealing and the [Solver Properties and Parameters](https://docs.dwavesys.com/docs/latest/doc_solver_ref.html) book describes the parameters used here.\n",
+    "The [What is Quantum Annealing?](https://docs.dwavequantum.com/en/latest/quantum_research/quantum_annealing_intro.html) page describes quantum annealing and the [QPU Solver Parameters](https://docs.dwavequantum.com/en/latest/quantum_research/solver_parameters.html) page describes the parameters used here.\n",
     "\n",
     "In brief, *anneal schedule* refers to the global annealing trajectory. It specifies the normalized anneal fraction, $s$, an abstract parameter ranging from 0 to 1. $s(t)$ is a continuous function starting at $s=0$ for time $t=0$ and ending with $s=1$ at $t=t_f$, the total time of the anneal.\n",
     "\n",
@@ -230,7 +230,7 @@
    "source": [
     "The structure of this problem maps neatly to the Chimera topology of a D-Wave 2000Q QPU: it can be minor-embedded directly into two side-by-side Chimera unit cells, with each problem qubit represented by one qubit on the QPU. On Advantage systems, the problem can be similarly represented by qubits in two of the Chimera unit cell's near-counterpart structure in the Pegasus topology: $K_{4,4}$ bicliques with additional *odd* couplers.\n",
     "\n",
-    "If you were to use a standard heuristic embedder such as [minorminer](https://docs.ocean.dwavesys.com/en/stable/docs_minorminer/source/sdk_index.html), however, some of the problem qubits might be represented by chains of qubits on the QPU. Instead, qubits of two ideal Chimera unit cells are used directly in the `h` and `J` definitions below and the `TilingComposite` composite scans adjacent unit cells on the QPU, finds adjacent pairs in which all the required qubits and couplers are available, and translates the one-to-one minor-embedding of the problem from the first two adjacent pairs to the first available valid pairs."
+    "If you were to use a standard heuristic embedder such as [minorminer](https://docs.dwavequantum.com/en/latest/ocean/api_ref_minorminer/source/index.html), however, some of the problem qubits might be represented by chains of qubits on the QPU. Instead, qubits of two ideal Chimera unit cells are used directly in the `h` and `J` definitions below and the `TilingComposite` composite scans adjacent unit cells on the QPU, finds adjacent pairs in which all the required qubits and couplers are available, and translates the one-to-one minor-embedding of the problem from the first two adjacent pairs to the first available valid pairs."
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ recommended.
 
 ## Usage
 
-Your development environment should be configured to 
-[access Leap’s Solvers](https://docs.ocean.dwavesys.com/en/stable/overview/sapi.html).
-You can see information about supported IDEs and authorizing access to your 
-Leap account [here](https://docs.dwavesys.com/docs/latest/doc_leap_dev_env.html).  
+Your development environment should be configured to
+[access Leap’s Solvers](https://docs.dwavequantum.com/en/latest/ocean/sapi_access_basic.html).
+You can see information about supported IDEs and authorizing access to your Leap
+account [here](https://docs.dwavequantum.com/en/latest/leap_sapi/dev_env.html).
 
 The notebook can be opened by clicking on the 
 ``01-anneal-schedule.ipynb`` file in VS Code-based IDEs. 

--- a/README.md
+++ b/README.md
@@ -16,39 +16,39 @@ normalized anneal fraction, ``s``, an abstract parameter ranging from 0 to 1.
 ``s(t)`` is a continuous function starting at ``s=0`` for time ``t=0``
 and ending with ``s=1`` at ``t=t_f``, the total time of the anneal.
 
-There are two ways to specify the anneal schedule, using two *mutually exclusive*
-parameters:
+There are two ways to specify the anneal schedule, using two
+*mutually exclusive* parameters:
 
-1. ``annealing_time``: Set to a number in microseconds to specify linear growth
-   from ``s=0`` to ``s=1`` over that time.
-2. ``annealing_schedule``: Specify a list of ``(t, s)`` pairs specifying
-   points, which are then linearly interpolated. This feature supports two
-   modes&mdash;mid-anneal pause and mid-anneal quench&mdash;which this tutorial
-   explores.
+1.  ``annealing_time``: Set to a number in microseconds to specify linear growth
+    from ``s=0`` to ``s=1`` over that time.
+2.  ``annealing_schedule``: Specify a list of ``(t, s)`` pairs specifying
+    points, which are then linearly interpolated. This feature supports two
+    modes&mdash;mid-anneal pause and mid-anneal quench&mdash;which this tutorial
+    explores.
 
 The notebook has the following sections:
 
-1. **Understanding the Anneal Schedule** explains the feature.
-2. **Using Anneal Schedule Features** shows how to use the feature with an
-   interactive example problem.
-3. **Mapping Various Anneal Schedules** provides code that sweeps through various
-   anneal schedules to explore the effect on results.
+1.  **Understanding the Anneal Schedule** explains the feature.
+2.  **Using Anneal Schedule Features** shows how to use the feature with an
+    interactive example problem.
+3.  **Mapping Various Anneal Schedules** provides code that sweeps through
+    various anneal schedules to explore the effect on results.
 
 ![pause](images/pause_success_fraction.png)
 
 ## Installation
 
-You can run this example without installation in cloud-based IDEs that support 
+You can run this example without installation in cloud-based IDEs that support
 the [Development Containers specification](https://containers.dev/supporting)
 (aka "devcontainers").
 
-For development environments that do not support ``devcontainers``, install 
+For development environments that do not support ``devcontainers``, install
 requirements:
 
     pip install -r requirements.txt
 
-If you are cloning the repo to your local system, working in a 
-[virtual environment](https://docs.python.org/3/library/venv.html) is 
+If you are cloning the repo to your local system, working in a
+[virtual environment](https://docs.python.org/3/library/venv.html) is
 recommended.
 
 ## Usage
@@ -58,8 +58,8 @@ Your development environment should be configured to
 You can see information about supported IDEs and authorizing access to your Leap
 account [here](https://docs.dwavequantum.com/en/latest/leap_sapi/dev_env.html).
 
-The notebook can be opened by clicking on the 
-``01-anneal-schedule.ipynb`` file in VS Code-based IDEs. 
+The notebook can be opened by clicking on the ``01-anneal-schedule.ipynb`` file
+in VS Code-based IDEs.
 
 To run a locally installed notebook:
 


### PR DESCRIPTION
[This commit](https://github.com/dwave-examples/anneal-schedule-notebook/commit/1bc9a529609881ce0427b84e74643fb0de8718d8) has the URL updates and is easier to review without the noise of the [2nd commit](https://github.com/dwave-examples/anneal-schedule-notebook/commit/d3a442c563281596331ac734d464ef5f57998475).